### PR TITLE
Added {Day}, {Weekday}, {Month}, {Mon}, {Month_Num}, {Year} tags

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -66,7 +66,14 @@
                                 <label class="inputLabel inputLabelUnfocused" for="Body">Body Html:</label>
                                 <div class="fieldDescription">
                                     See below for Field Names to use in your custom HTML:<br>
-                                    {Date} - The date of Newsletter generation. <br>
+                                    All the date fields you see below refer to the date of Newsletter generation/creation. To demonstrate, imagine it's Tuesday, the 21. August 2024:<br>
+                                    {Date} - Will be formatted to match your region-specific date format. Example: 08/21/2024<br>
+                                    {Day} - The day of the month. Example: 21<br>
+                                    {Weekday} - The day of the week. Example: Tuesday<br>
+                                    {Month} - The full name of the month. Example: August<br>
+                                    {Mon} - The first three letters of the month. Example: Aug<br>
+                                    {Month_Num} - The month number. Example: 08<br>
+                                    {Year} - The year. Example: 2024<br>
                                     {EntryData} - This is the insert of the custom HTML from the field EntryData below. If not used, email will have no data. <br>
                                 </div>
                                 <textarea id="Body" name="Body" dataname="Body" style="width: 100%; height: 400px"></textarea>

--- a/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
@@ -101,8 +101,23 @@ public class Smtp : ControllerBase
                 // string finalBody = hb.ReplaceBodyWithBuiltString(body, builtString);
                 // string finalBody = hb.TemplateReplace(hb.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", config.Hostname);
                 builtString = hb.TemplateReplace(hb.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", config.Hostname);
-                string currDate = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-                builtString = builtString.Replace("{Date}", currDate, StringComparison.Ordinal);
+                 Dictionary<string, string> dateFormats = new Dictionary<string, string>
+                {
+                    { "{Date}", "d" },          // Short date format based on current culture
+                    { "{Day}", "dd" },          // Day of the month (two digits)
+                    { "{Weekday}", "dddd" },    // Full weekday name
+                    { "{Month}", "MMMM" },      // Full month name
+                    { "{Mon}", "MMM" },         // Abbreviated month name (three letters)
+                    { "{Month_Num}", "MM" },    // Month number (two digits)
+                    { "{Year}", "yyyy" }        // Four-digit year
+                };
+                foreach (var kvp in dateFormats)
+                {
+                    string format = kvp.Value;
+                    string formattedDate = DateTime.Today.ToString(format, System.Globalization.CultureInfo.CurrentCulture);
+                    builtString = builtString.Replace(kvp.Key, formattedDate, StringComparison.Ordinal);
+                }
+
 
                 mail.From = new MailAddress(emailFromAddress, emailFromAddress);
                 mail.To.Clear();


### PR DESCRIPTION
Added tags:

{Day} → Output = 21
{Weekday} → Output = Tuesday
{Month} → Output = August
{Mon} → Output = Aug
{Month_Num} → Output = 08
{Year} → Output = 2024
These dates will now be formatted depending on the cultureinfo. So if the system's culture is de-DE then the weekdays and months will be in German.

Changed:
{Date} = The tag will now use the system culture to determine how it formats the date. 
For example: in Germany it will automatically use "21.08.2024" while in the US it'll use "08/21/2024"

The new tags were added to the config page with an example. I didn't want to add the tags to the README yet. Please take into consideration that this is my first commit in C#, but since the changes weren't all too big, it should hopefully work :)